### PR TITLE
Git utilities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.workflow.utils
 Title: Utility functions for PACTA workflows
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,13 +17,13 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Imports: 
     digest,
+    gert,
     jsonlite,
     logger,
     pkgdepends,
     pkgload
 Suggests: 
     devtools,
-    gert,
     pak,
     testthat (>= 3.0.0),
     withr

--- a/R/get_package_info.R
+++ b/R/get_package_info.R
@@ -124,6 +124,24 @@ get_individual_package_info <- function(packagename) {
       )
     )
     pkg_details[["library_index"]] <- lib_index
+    if (is.null(pkg_details[["remotepkgref"]])) {
+      is_local_pkg <- FALSE
+    } else {
+      is_local_pkg <- grepl(
+        x = pkg_details[["remotepkgref"]],
+        pattern = "^local::"
+      )
+    }
+    if (is_local_pkg) {
+      git_info <- get_git_info(
+        repo = gsub(
+          x = pkg_details[["remotepkgref"]],
+          pattern = "local::",
+          replacement = ""
+        )
+      )
+      pkg_details[["git"]] <- git_info
+    }
   }
   details_list <- list(
     package = pkg_details[["package"]],

--- a/R/get_package_info.R
+++ b/R/get_package_info.R
@@ -80,6 +80,7 @@ get_individual_package_info <- function(packagename) {
     package_dev_dir <- pkgload::pkg_path(
       path = dirname(system.file("DESCRIPTION", package = packagename))
     )
+    git_info <- get_git_info(repo = package_dev_dir)
     pkg_details <- list(
       package = pkgload::pkg_name(package_dev_dir),
       version = paste("DEV", pkgload::pkg_version(package_dev_dir)),
@@ -91,7 +92,8 @@ get_individual_package_info <- function(packagename) {
       remotetype = "pkgload",
       remotepkgref = normalizePath(package_dev_dir),
       remoteref = NA_character_,
-      remotesha = NA_character_
+      remotesha = NA_character_,
+      git = git_info
     )
   } else {
     if (packagename %in% utils::installed.packages()[, "Package"]) {
@@ -135,12 +137,17 @@ get_individual_package_info <- function(packagename) {
     remotetype = pkg_details[["remotetype"]],
     remotepkgref = pkg_details[["remotepkgref"]],
     remoteref = pkg_details[["remoteref"]],
-    remotesha = pkg_details[["remotesha"]]
+    remotesha = pkg_details[["remotesha"]],
+    git = pkg_details[["git"]]
   )
   clean_details_list <- lapply(
     X = details_list,
     FUN = function(x) {
-      ifelse(is.null(x), NA_character_, x)
+      if (is.null(x)) {
+        NA_character_
+      } else {
+        x
+      }
     }
   )
   return(clean_details_list)

--- a/R/get_package_info.R
+++ b/R/get_package_info.R
@@ -137,7 +137,8 @@ get_individual_package_info <- function(packagename) {
         repo = gsub(
           x = pkg_details[["remotepkgref"]],
           pattern = "local::",
-          replacement = ""
+          replacement = "",
+          fixed = TRUE
         )
       )
       pkg_details[["git"]] <- git_info

--- a/R/git.R
+++ b/R/git.R
@@ -113,6 +113,3 @@ git_changed_files <- function(repo) {
     return(NULL)
   }
 }
-
-
-# TODO: Conflicted Repos https://github.com/r-lib/gert/pull/40

--- a/R/git.R
+++ b/R/git.R
@@ -8,11 +8,14 @@ get_git_info <- function(repo) {
       log_debug("No commits found in repo.")
       latest_commit <- NULL
     }
+    changed_files <- git_changed_files(repo = git_repo)
     out <- list(
       repo = normalizePath(info[["path"]]),
       is_git = TRUE,
+      commit = latest_commit,
+      clean = (length(changed_files) == 0),
       branch = git_branch_info(repo = repo),
-      commit = latest_commit
+      changed_files = changed_files
     )
   } else {
     log_warn("Directory \"{repo}\" is not a git repository.")
@@ -94,5 +97,22 @@ git_branch_info <- function(repo) {
   }
   return(out)
 }
+
+git_changed_files <- function(repo) {
+  log_trace("checking for changed files in repo \"{repo}\".")
+  if (is_git_path(repo)) {
+    git_repo <- gert::git_find(path = repo)
+    status <- gert::git_status(repo = git_repo)
+    changed_files <- list()
+    for (f in status[["file"]]) {
+      changed_files[[f]] <- status[["status"]][status[["file"]] == f]
+    }
+    return(changed_files)
+  } else {
+    log_debug("Specified path is not in a git repository.")
+    return(NULL)
+  }
+}
+
 
 # TODO: Conflicted Repos https://github.com/r-lib/gert/pull/40

--- a/R/git.R
+++ b/R/git.R
@@ -13,7 +13,7 @@ get_git_info <- function(repo) {
       repo = normalizePath(info[["path"]]),
       is_git = TRUE,
       commit = latest_commit,
-      clean = (length(changed_files) == 0),
+      clean = (length(changed_files) == 0L),
       branch = git_branch_info(repo = repo),
       changed_files = changed_files
     )
@@ -69,17 +69,29 @@ git_branch_info <- function(repo) {
       active_upstream <- NULL
       up_to_date <- NULL
       upstream_commit <- NULL
-      remote_url = NULL
+      remote_url <- NULL
     } else {
-      log_trace("Branch \"{active_branch}\" has an upstream: \"{active_upstream}\".")
-      active_upstream <- gsub("refs/heads/", "", active_upstream)
+      log_trace(
+        "Branch \"{active_branch}\" has an upstream: \"{active_upstream}\"."
+      )
+      active_upstream <- gsub(
+        pattern = "refs/heads/", # nolint: nonportable_path_linter
+        replacement = "",
+        x = active_upstream
+      )
       upstream_index <- which(branch_list[["ref"]] == active_upstream)
       upstream_commit <- branch_list[[upstream_index, "commit"]]
       up_to_date <- active_commit == upstream_commit
-      remote_list <- gert::git_remote_list(repo = git_repo)
-      # refs/remotes/origin/branch
-      remote_name <- strsplit(x = active_upstream, split = "/")[[1]][3]
-      remote_info <- gert::git_remote_info(repo = git_repo, remote = remote_name)
+      # format of remote ref: refs/remotes/origin/branch
+      remote_name <- strsplit(
+        x = active_upstream,
+        split = "/",
+        fixed = TRUE
+      )[[1L]][[3L]]
+      remote_info <- gert::git_remote_info(
+        repo = git_repo,
+        remote = remote_name
+      )
       remote_url <- remote_info[["url"]]
     }
     out <- list(

--- a/R/git.R
+++ b/R/git.R
@@ -9,8 +9,15 @@ get_git_info <- function(repo) {
       latest_commit <- NULL
     }
     changed_files <- git_changed_files(repo = git_repo)
+    # cleaning path for older versions of R on windows
+    repo_path <- gsub(
+      x = normalizePath(info[["path"]]),
+      pattern = "\\\\$",
+      replacement = "",
+      fixed = TRUE
+    )
     out <- list(
-      repo = normalizePath(info[["path"]]),
+      repo = repo_path,
       is_git = TRUE,
       commit = latest_commit,
       clean = (length(changed_files) == 0L),

--- a/R/git.R
+++ b/R/git.R
@@ -12,7 +12,7 @@ get_git_info <- function(repo) {
     # cleaning path for older versions of R on windows
     repo_path <- gsub(
       x = normalizePath(info[["path"]]),
-      pattern = "\\$",
+      pattern = "[\\/]+$",
       replacement = "",
       fixed = TRUE
     )

--- a/R/git.R
+++ b/R/git.R
@@ -12,7 +12,7 @@ get_git_info <- function(repo) {
     # cleaning path for older versions of R on windows
     repo_path <- gsub(
       x = normalizePath(info[["path"]]),
-      pattern = "\\\\$",
+      pattern = "\\$",
       replacement = "",
       fixed = TRUE
     )

--- a/R/git.R
+++ b/R/git.R
@@ -1,34 +1,98 @@
 get_git_info <- function(repo) {
   log_trace("checking that directory \"{repo}\"exists.")
-  if (dir.exists(repo)) {
-    if (is_git_path(repo)) {
-    } else {
-      log_warn("directory \"{repo}\" is not a git repository.")
-      warning("Directory \"{repo}\" is not a git repository")
-      out <- list()
+  if (is_git_path(repo)) {
+    git_repo <- gert::git_find(path = repo)
+    info <- gert::git_info(repo = git_repo)
+    latest_commit <- info[["commit"]]
+    if (is.na(latest_commit)) {
+      log_debug("No commits found in repo.")
+      latest_commit <- NULL
     }
+    out <- list(
+      repo = normalizePath(info[["path"]]),
+      is_git = TRUE,
+      branch = git_branch_info(repo = repo),
+      commit = latest_commit
+    )
   } else {
-    # dir does not exist
-    log_warn("directory \"{repo}\" does not exist.")
-    warning("Cannot find git information for directory which does not exist")
-    out <- list()
+    log_warn("Directory \"{repo}\" is not a git repository.")
+    warning("Specified path is not in a git repository.")
+    out <- NULL
   }
   return(out)
 }
 
 is_git_path <- function(path) {
-  log_trace("checking that path \"{path}\" exists.")
+  log_trace("checking that path \"{path}\" is in a git repository.")
   if (file.exists(path)) {
-    out <- tryCatch({
-      git_path <- gert::git_find(path = path)
-      dir.exists(git_path)
+    log_trace("path \"{path}\" exists.")
+    git_path <- tryCatch({
+      gert::git_find(path = path)
     }, error = function(e) {
-      FALSE
+      log_trace("error while finding git repo in parent tree for \"{path}\".")
+      NULL
     })
+    if (is.null(git_path)) {
+      log_trace("no git repo found in parent tree for \"{path}\".")
+      is_git_path <- FALSE
+    } else {
+      log_trace("git repo found in parent tree for \"{path}\".")
+      is_git_path <- dir.exists(git_path)
+    }
   } else {
     # dir does not exist
     log_error("path \"{path}\" does not exist.")
     stop("Cannot find git information for path which does not exist.")
   }
+  return(is_git_path)
+}
+
+git_branch_info <- function(repo) {
+  log_trace("checking branch information for repo \"{repo}\".")
+  if (is_git_path(repo)) {
+    git_repo <- gert::git_find(path = repo)
+    active_branch <- gert::git_branch(repo = git_repo)
+    if (is.null(active_branch)) {
+      log_debug("No active branch found.")
+      return(NULL)
+    }
+    log_debug("active branch: \"{active_branch}\".")
+    branch_list <- gert::git_branch_list(repo = git_repo)
+    active_index <- which(branch_list[["name"]] == active_branch)
+    active_commit <- branch_list[[active_index, "commit"]]
+    active_upstream <- branch_list[[active_index, "upstream"]]
+    if (is.na(active_upstream)) {
+      log_debug("Branch \"{active_branch}\" has no upstream.")
+      active_upstream <- NULL
+      up_to_date <- NULL
+      upstream_commit <- NULL
+      remote_url = NULL
+    } else {
+      log_trace("Branch \"{active_branch}\" has an upstream: \"{active_upstream}\".")
+      active_upstream <- gsub("refs/heads/", "", active_upstream)
+      upstream_index <- which(branch_list[["ref"]] == active_upstream)
+      upstream_commit <- branch_list[[upstream_index, "commit"]]
+      up_to_date <- active_commit == upstream_commit
+      remote_list <- gert::git_remote_list(repo = git_repo)
+      # refs/remotes/origin/branch
+      remote_name <- strsplit(x = active_upstream, split = "/")[[1]][3]
+      remote_info <- gert::git_remote_info(repo = git_repo, remote = remote_name)
+      remote_url <- remote_info[["url"]]
+    }
+    out <- list(
+      name = active_branch,
+      commit = active_commit,
+      upstream = active_upstream,
+      remote_url = remote_url,
+      up_to_date = up_to_date,
+      upstream_commit = upstream_commit
+    )
+  } else {
+    log_warn("Directory \"{repo}\" is not a git repository.")
+    warning("Specified path is not in a git repository.")
+    out <- NULL
+  }
   return(out)
 }
+
+# TODO: Conflicted Repos https://github.com/r-lib/gert/pull/40

--- a/R/git.R
+++ b/R/git.R
@@ -12,9 +12,8 @@ get_git_info <- function(repo) {
     # cleaning path for older versions of R on windows
     repo_path <- gsub(
       x = normalizePath(info[["path"]]),
-      pattern = "[\\/]+$",
-      replacement = "",
-      fixed = TRUE
+      pattern = "[\\]+$", # nolint: nonportable_path_linter
+      replacement = ""
     )
     out <- list(
       repo = repo_path,

--- a/R/git.R
+++ b/R/git.R
@@ -1,0 +1,34 @@
+get_git_info <- function(repo) {
+  log_trace("checking that directory \"{repo}\"exists.")
+  if (dir.exists(repo)) {
+    if (is_git_path(repo)) {
+    } else {
+      log_warn("directory \"{repo}\" is not a git repository.")
+      warning("Directory \"{repo}\" is not a git repository")
+      out <- list()
+    }
+  } else {
+    # dir does not exist
+    log_warn("directory \"{repo}\" does not exist.")
+    warning("Cannot find git information for directory which does not exist")
+    out <- list()
+  }
+  return(out)
+}
+
+is_git_path <- function(path) {
+  log_trace("checking that path \"{path}\" exists.")
+  if (file.exists(path)) {
+    out <- tryCatch({
+      git_path <- gert::git_find(path = path)
+      dir.exists(git_path)
+    }, error = function(e) {
+      FALSE
+    })
+  } else {
+    # dir does not exist
+    log_error("path \"{path}\" does not exist.")
+    stop("Cannot find git information for path which does not exist.")
+  }
+  return(out)
+}

--- a/tests/testthat/helper-git_config.R
+++ b/tests/testthat/helper-git_config.R
@@ -1,0 +1,8 @@
+testing_git_config <- function(repo) {
+  gert::git_config_set(repo = repo, name = "user.name", value = "testthat")
+  gert::git_config_set(
+    repo = repo,
+    name = "user.email",
+    value = "PACTATesting@rmi.org"
+  )
+}

--- a/tests/testthat/helper-remote_package.R
+++ b/tests/testthat/helper-remote_package.R
@@ -1,0 +1,12 @@
+remote_package <- list(
+  name = "minimal.r.package",
+  version = "0.0.0.9001",
+  old_version = "0.0.0.9000",
+  gh_repo = "RMI-PACTA/minimal.r.package",
+  gh_repo_old = "RMI-PACTA/minimal.r.package@28c716f",
+  branch = "main",
+  upstream = "refs/remotes/origin/main",
+  url = "https://github.com/RMI-PACTA/minimal.r.package.git",
+  sha = "f31fa0e5675b675fb778e15fcf1501aecec8cf94",
+  old_sha = "28c716face8bbf8787c32ae392f246177f111c00"
+)

--- a/tests/testthat/helper-remote_package.R
+++ b/tests/testthat/helper-remote_package.R
@@ -2,10 +2,10 @@ remote_package <- list(
   name = "minimal.r.package",
   version = "0.0.0.9001",
   old_version = "0.0.0.9000",
-  gh_repo = "RMI-PACTA/minimal.r.package",
-  gh_repo_old = "RMI-PACTA/minimal.r.package@28c716f",
+  gh_repo = "RMI-PACTA/minimal.r.package", #nolint: nonportable_path_linter
+  gh_repo_old = "RMI-PACTA/minimal.r.package@28c716f", #nolint: nonportable_path_linter
   branch = "main",
-  upstream = "refs/remotes/origin/main",
+  upstream = "refs/remotes/origin/main", #nolint: nonportable_path_linter
   url = "https://github.com/RMI-PACTA/minimal.r.package.git",
   sha = "f31fa0e5675b675fb778e15fcf1501aecec8cf94",
   old_sha = "28c716face8bbf8787c32ae392f246177f111c00"

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -13,15 +13,6 @@ logger::log_appender(logger::appender_stdout)
 logger::log_threshold(logger::FATAL)
 logger::log_layout(logger::layout_simple)
 
-testing_git_config <- function(repo) {
-  gert::git_config_set(repo = repo, name = "user.name", value = "testthat")
-  gert::git_config_set(
-    repo = repo,
-    name = "user.email",
-    value = "PACTATesting@rmi.org"
-  )
-}
-
 # TESTS BEGIN
 test_that("get_git_info processes non-git-repo correctly", {
   test_dir <- withr::local_tempdir()
@@ -243,7 +234,7 @@ test_that("get_git_info processes cloned git repo", {
   testthat::skip_if_offline()
   test_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    url = remote_package[["url"]], #nolint: nonportable_path_linter
     path = test_dir,
     verbose = FALSE
   )
@@ -253,15 +244,15 @@ test_that("get_git_info processes cloned git repo", {
     list(
       repo = normalizePath(test_dir),
       is_git = TRUE,
-      commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+      commit = remote_package[["sha"]],
       clean = TRUE,
       branch = list(
-        name = "master",
-        commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
-        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
-        remote_url = "https://github.com/yihui/rmini.git",
+        name = remote_package[["branch"]],
+        commit = remote_package[["sha"]],
+        upstream = remote_package[["upstream"]],
+        remote_url = remote_package[["url"]],
         up_to_date = TRUE,
-        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+        upstream_commit = remote_package[["sha"]]
       ),
       changed_files = list(),
       tags = list()
@@ -274,7 +265,7 @@ test_that("get_git_info processes cloned git repo with local dirty", {
   testthat::skip_if_offline()
   test_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    url = remote_package[["url"]], #nolint: nonportable_path_linter
     path = test_dir,
     verbose = FALSE
   )
@@ -286,15 +277,15 @@ test_that("get_git_info processes cloned git repo with local dirty", {
     list(
       repo = normalizePath(test_dir),
       is_git = TRUE,
-      commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+      commit = remote_package[["sha"]],
       clean = FALSE,
       branch = list(
-        name = "master",
-        commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
-        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
-        remote_url = "https://github.com/yihui/rmini.git",
+        name = remote_package[["branch"]],
+        commit = remote_package[["sha"]],
+        upstream = remote_package[["upstream"]],
+        remote_url = remote_package[["url"]],
         up_to_date = TRUE,
-        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+        upstream_commit = remote_package[["sha"]]
       ),
       changed_files = list(
         foo.txt = "new"
@@ -309,7 +300,7 @@ test_that("get_git_info processes cloned git repo with local commit", {
   testthat::skip_if_offline()
   test_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    url = remote_package[["url"]], #nolint: nonportable_path_linter
     path = test_dir,
     verbose = FALSE
   )
@@ -327,12 +318,12 @@ test_that("get_git_info processes cloned git repo with local commit", {
       commit = commit_sha,
       clean = TRUE,
       branch = list(
-        name = "master",
+        name = remote_package[["branch"]],
         commit = commit_sha,
-        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
-        remote_url = "https://github.com/yihui/rmini.git",
+        upstream = remote_package[["upstream"]],
+        remote_url = remote_package[["url"]],
         up_to_date = FALSE,
-        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+        upstream_commit = remote_package[["sha"]]
       ),
       changed_files = list(),
       tags = list()

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -34,26 +34,50 @@ test_that("get_git_info processes fresh git repo correctly", {
     list(
       repo = normalizePath(test_dir),
       is_git = TRUE,
+      commit = NULL,
+      clean = TRUE,
       branch = NULL,
-      commit = NULL
+      changed_files = list()
     )
   )
 })
 
-test_that("get_git_info processes git repo with a single commit correctly", {
+test_that("get_git_info processes fresh git repo with new file correctly", {
   test_dir <- withr::local_tempdir()
-  test_file <- withr::local_tempfile(tmpdir = test_dir, fileext = ".txt")
-  writeLines("Hello, world!", con = test_file)
   gert::git_init(path = test_dir)
-  gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
-  commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
-
+  test_file <- file.path(test_dir, "foo.txt")
+  writeLines("Hello, world!", con = test_file)
   metadata <- get_git_info(repo = test_dir)
   expect_identical(
     metadata,
     list(
       repo = normalizePath(test_dir),
       is_git = TRUE,
+      commit = NULL,
+      clean = FALSE,
+      branch = NULL,
+      changed_files = list(
+        foo.txt = "new"
+      )
+    )
+  )
+})
+
+test_that("get_git_info processes git repo with a single commit correctly", {
+  test_dir <- withr::local_tempdir()
+  test_file <- file.path(test_dir, "foo.txt")
+  writeLines("Hello, world!", con = test_file)
+  gert::git_init(path = test_dir)
+  gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
+  commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      commit = commit_sha,
+      clean = TRUE,
       branch = list(
         name = "master",
         commit = commit_sha,
@@ -62,10 +86,43 @@ test_that("get_git_info processes git repo with a single commit correctly", {
         up_to_date = NULL,
         upstream_commit = NULL
       ),
-      commit = commit_sha
+      changed_files = list()
+    )
+  )
+})
+
+test_that("get_git_info processes git repo with dirty index correctly", {
+  test_dir <- withr::local_tempdir()
+  test_file <- file.path(test_dir, "foo.txt")
+  writeLines("Hello, world!", con = test_file)
+  gert::git_init(path = test_dir)
+  gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
+  commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
+  writeLines("Hello, Testing!", con = test_file)
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      commit = commit_sha,
+      clean = FALSE,
+      branch = list(
+        name = "master",
+        commit = commit_sha,
+        upstream = NULL,
+        remote_url = NULL,
+        up_to_date = NULL,
+        upstream_commit = NULL
+      ),
+      changed_files = list(
+        foo.txt = "modified"
+      )
     )
   )
 })
 
 # TODO: dirty/clean
 # TODO: Diffs
+
+# moved file

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -13,6 +13,15 @@ logger::log_appender(logger::appender_stdout)
 logger::log_threshold(logger::FATAL)
 logger::log_layout(logger::layout_simple)
 
+testing_git_config <- function(repo) {
+  gert::git_config_set(repo = repo, name = "user.name", value = "testthat")
+  gert::git_config_set(
+    repo = repo,
+    name = "user.email",
+    value = "PACTATesting@rmi.org"
+  )
+}
+
 # TESTS BEGIN
 test_that("get_git_info processes non-git-repo correctly", {
   test_dir <- withr::local_tempdir()
@@ -70,6 +79,7 @@ test_that("get_git_info processes git repo with a single commit correctly", {
   test_file <- file.path(test_dir, "foo.txt")
   writeLines("Hello, world!", con = test_file)
   gert::git_init(path = test_dir)
+  testing_git_config(repo = test_dir)
   gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
   commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
   metadata <- get_git_info(repo = test_dir)
@@ -99,6 +109,7 @@ test_that("get_git_info processes git repo with dirty index correctly", {
   test_file <- file.path(test_dir, "foo.txt")
   writeLines("Hello, world!", con = test_file)
   gert::git_init(path = test_dir)
+  testing_git_config(repo = test_dir)
   gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
   commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
   writeLines("Hello, Testing!", con = test_file)
@@ -131,6 +142,7 @@ test_that("get_git_info processes git repo with conflicts correctly", {
   test_file <- file.path(test_dir, "foo.txt")
   writeLines("Hello, world!", con = test_file)
   gert::git_init(path = test_dir)
+  testing_git_config(repo = test_dir)
   gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
   gert::git_commit(repo = test_dir, message = "Initial commit")
 
@@ -178,6 +190,7 @@ test_that("get_git_info processes git repo with tags correctly", {
   test_file <- file.path(test_dir, "foo.txt")
   writeLines("Hello, world!", con = test_file)
   gert::git_init(path = test_dir)
+  testing_git_config(repo = test_dir)
   gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
   commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
   foo_sha <- gert::git_tag_create(

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -258,7 +258,7 @@ test_that("get_git_info processes cloned git repo", {
       branch = list(
         name = "master",
         commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
-        upstream = "refs/remotes/origin/master",
+        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
         remote_url = "https://github.com/yihui/rmini.git",
         up_to_date = TRUE,
         upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
@@ -291,7 +291,7 @@ test_that("get_git_info processes cloned git repo with local dirty", {
       branch = list(
         name = "master",
         commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
-        upstream = "refs/remotes/origin/master",
+        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
         remote_url = "https://github.com/yihui/rmini.git",
         up_to_date = TRUE,
         upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
@@ -329,7 +329,7 @@ test_that("get_git_info processes cloned git repo with local commit", {
       branch = list(
         name = "master",
         commit = commit_sha,
-        upstream = "refs/remotes/origin/master",
+        upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
         remote_url = "https://github.com/yihui/rmini.git",
         up_to_date = FALSE,
         upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
@@ -339,4 +339,3 @@ test_that("get_git_info processes cloned git repo with local commit", {
     )
   )
 })
-

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -140,7 +140,9 @@ test_that("get_git_info processes git repo with conflicts correctly", {
   gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
   commit_sha <- gert::git_commit(repo = test_dir, message = "Master commit")
 
-  gert::git_merge(repo = test_dir, ref = "feature")
+  suppressMessages(
+    gert::git_merge(repo = test_dir, ref = "feature")
+  )
 
   metadata <- get_git_info(repo = test_dir)
   expect_identical(

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -1,0 +1,71 @@
+## save current settings so that we can reset later
+threshold <- logger::log_threshold()
+appender  <- logger::log_appender()
+layout    <- logger::log_layout()
+on.exit({
+  ## reset logger settings
+  logger::log_threshold(threshold)
+  logger::log_layout(layout)
+  logger::log_appender(appender)
+})
+
+logger::log_appender(logger::appender_stdout)
+logger::log_threshold(logger::FATAL)
+logger::log_layout(logger::layout_simple)
+
+# TESTS BEGIN
+test_that("get_git_info processes non-git-repo correctly", {
+  test_dir <- withr::local_tempdir()
+  expect_warning(
+    object = {
+      metadata <- get_git_info(repo = test_dir)
+    },
+    regexp = "^Specified path is not in a git repository.$"
+  )
+  expect_null(metadata)
+})
+
+test_that("get_git_info processes fresh git repo correctly", {
+  test_dir <- withr::local_tempdir()
+  gert::git_init(path = test_dir)
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      branch = NULL,
+      commit = NULL
+    )
+  )
+})
+
+test_that("get_git_info processes git repo with a single commit correctly", {
+  test_dir <- withr::local_tempdir()
+  test_file <- withr::local_tempfile(tmpdir = test_dir, fileext = ".txt")
+  writeLines("Hello, world!", con = test_file)
+  gert::git_init(path = test_dir)
+  gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
+  commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
+
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      branch = list(
+        name = "master",
+        commit = commit_sha,
+        upstream = NULL,
+        remote_url = NULL,
+        up_to_date = NULL,
+        upstream_commit = NULL
+      ),
+      commit = commit_sha
+    )
+  )
+})
+
+# TODO: dirty/clean
+# TODO: Diffs

--- a/tests/testthat/test-get_git_info.R
+++ b/tests/testthat/test-get_git_info.R
@@ -237,3 +237,106 @@ test_that("get_git_info processes git repo with tags correctly", {
     )
   )
 })
+
+test_that("get_git_info processes cloned git repo", {
+  testthat::skip_on_cran()
+  testthat::skip_if_offline()
+  test_dir <- normalizePath(withr::local_tempdir())
+  dl <- gert::git_clone(
+    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    path = test_dir,
+    verbose = FALSE
+  )
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+      clean = TRUE,
+      branch = list(
+        name = "master",
+        commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+        upstream = "refs/remotes/origin/master",
+        remote_url = "https://github.com/yihui/rmini.git",
+        up_to_date = TRUE,
+        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+      ),
+      changed_files = list(),
+      tags = list()
+    )
+  )
+})
+
+test_that("get_git_info processes cloned git repo with local dirty", {
+  testthat::skip_on_cran()
+  testthat::skip_if_offline()
+  test_dir <- normalizePath(withr::local_tempdir())
+  dl <- gert::git_clone(
+    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    path = test_dir,
+    verbose = FALSE
+  )
+  test_file <- file.path(test_dir, "foo.txt")
+  writeLines("Hello, world!", con = test_file)
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+      clean = FALSE,
+      branch = list(
+        name = "master",
+        commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+        upstream = "refs/remotes/origin/master",
+        remote_url = "https://github.com/yihui/rmini.git",
+        up_to_date = TRUE,
+        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+      ),
+      changed_files = list(
+        foo.txt = "new"
+      ),
+      tags = list()
+    )
+  )
+})
+
+test_that("get_git_info processes cloned git repo with local commit", {
+  testthat::skip_on_cran()
+  testthat::skip_if_offline()
+  test_dir <- normalizePath(withr::local_tempdir())
+  dl <- gert::git_clone(
+    url = "https://github.com/yihui/rmini.git", #nolint: nonportable_path_linter
+    path = test_dir,
+    verbose = FALSE
+  )
+  testing_git_config(repo = test_dir)
+  test_file <- file.path(test_dir, "foo.txt")
+  writeLines("Hello, world!", con = test_file)
+  gert::git_add(files = basename(test_file), repo = normalizePath(test_dir))
+  commit_sha <- gert::git_commit(repo = test_dir, message = "Initial commit")
+  metadata <- get_git_info(repo = test_dir)
+  expect_identical(
+    metadata,
+    list(
+      repo = normalizePath(test_dir),
+      is_git = TRUE,
+      commit = commit_sha,
+      clean = TRUE,
+      branch = list(
+        name = "master",
+        commit = commit_sha,
+        upstream = "refs/remotes/origin/master",
+        remote_url = "https://github.com/yihui/rmini.git",
+        up_to_date = FALSE,
+        upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+      ),
+      changed_files = list(),
+      tags = list()
+    )
+  )
+})
+

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -73,7 +73,7 @@ expect_package_info <- function(
   } else {
     testthat::expect_in(
       object = package_info[["library"]],
-      .libPaths() #nolint: undesirable_function_linter
+      .libPaths() # nolint: undesirable_function_linter
     )
     testthat::expect_gt(
       object = package_info[["library_index"]],
@@ -81,7 +81,7 @@ expect_package_info <- function(
     )
     testthat::expect_lte(
       object = package_info[["library_index"]],
-      expected = length(.libPaths()) #nolint: undesirable_function_linter
+      expected = length(.libPaths()) # nolint: undesirable_function_linter
     )
     testthat::expect_match(
       object = package_info[["platform"]],
@@ -91,7 +91,7 @@ expect_package_info <- function(
 
   testthat::expect_identical(
     object = package_info[["library"]],
-    expected = .libPaths()[package_info[["library_index"]]] #nolint: undesirable_function_linter
+    expected = .libPaths()[package_info[["library_index"]]] # nolint: undesirable_function_linter
   )
   testthat::expect_type(
     object = package_info[["library_index"]],
@@ -198,7 +198,7 @@ test_that("get_individual_package_info collects information for local packages c
   testthat::skip_if_offline()
   dest_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = remote_package[["url"]], #nolint: nonportable_path_linter
+    url = remote_package[["url"]],
     path = dest_dir,
     verbose = FALSE
   )
@@ -222,7 +222,7 @@ test_that("get_individual_package_info collects information for local packages c
         branch = list(
           name = remote_package[["branch"]],
           commit = remote_package[["sha"]],
-          upstream = remote_package[["upstream"]], #nolint: nonportable_path_linter
+          upstream = remote_package[["upstream"]],
           remote_url = remote_package[["url"]],
           up_to_date = TRUE,
           upstream_commit = remote_package[["sha"]]
@@ -242,7 +242,7 @@ test_that("get_individual_package_info collects information for GitHub packages 
   testthat::skip_on_cran()
   testthat::skip_if_offline()
   new_lib <- normalizePath(withr::local_tempdir())
-  package_info <- with_local_install(new_lib, remote_package[["gh_repo"]], { #nolint: nonportable_path_linter
+  package_info <- with_local_install(new_lib, remote_package[["gh_repo"]], {
     package_info <- get_individual_package_info(remote_package[["name"]])
     expect_package_info(
       package_info,
@@ -250,7 +250,7 @@ test_that("get_individual_package_info collects information for GitHub packages 
       version_identical = remote_package[["version"]],
       repository_match = NA_character_,
       remotetype_identical = "github",
-      remotepkgref_match = paste0("^", remote_package[["gh_repo"]], "$"), #nolint: nonportable_path_linter
+      remotepkgref_match = paste0("^", remote_package[["gh_repo"]], "$"),
       remoteref_identical = "HEAD",
       remotesha_identical = remote_package[["sha"]]
     )
@@ -267,7 +267,7 @@ test_that("get_individual_package_info collects information for packages loaded 
   testthat::skip_if_not_installed("pkgload")
   dest_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = remote_package[["url"]], #nolint: nonportable_path_linter
+    url = remote_package[["url"]],
     path = dest_dir,
     verbose = FALSE
   )
@@ -296,7 +296,7 @@ test_that("get_individual_package_info collects information for packages loaded 
           branch = list(
             name = remote_package[["branch"]],
             commit = remote_package[["sha"]],
-            upstream = remote_package[["upstream"]], #nolint: nonportable_path_linter
+            upstream = remote_package[["upstream"]],
             remote_url = remote_package[["url"]],
             up_to_date = TRUE,
             upstream_commit = remote_package[["sha"]]
@@ -320,7 +320,7 @@ test_that("get_individual_package_info collects information for packages loaded 
   testthat::skip_if_not_installed("devtools")
   dest_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = remote_package[["url"]], #nolint: nonportable_path_linter
+    url = remote_package[["url"]],
     path = dest_dir,
     verbose = FALSE
   )
@@ -349,7 +349,7 @@ test_that("get_individual_package_info collects information for packages loaded 
           branch = list(
             name = remote_package[["branch"]],
             commit = remote_package[["sha"]],
-            upstream = remote_package[["upstream"]], #nolint: nonportable_path_linter
+            upstream = remote_package[["upstream"]],
             remote_url = remote_package[["url"]],
             up_to_date = TRUE,
             upstream_commit = remote_package[["sha"]]
@@ -373,7 +373,7 @@ test_that("get_individual_package_info collects information for altered packages
   testthat::skip_if_not_installed("devtools")
   dest_dir <- normalizePath(withr::local_tempdir())
   dl <- gert::git_clone(
-    url = remote_package[["url"]], #nolint: nonportable_path_linter
+    url = remote_package[["url"]],
     path = dest_dir,
     verbose = FALSE
   )
@@ -408,7 +408,7 @@ test_that("get_individual_package_info collects information for altered packages
           branch = list(
             name = remote_package[["branch"]],
             commit = commit_sha,
-            upstream = remote_package[["upstream"]], #nolint: nonportable_path_linter
+            upstream = remote_package[["upstream"]],
             remote_url = remote_package[["url"]],
             up_to_date = FALSE,
             upstream_commit = remote_package[["sha"]]
@@ -459,8 +459,8 @@ test_that("get_individual_package_info gets correct libpath and version of multi
   new_lib <- normalizePath(withr::local_tempdir())
   newer_lib <- normalizePath(withr::local_tempdir())
   expect_warning(
-    with_local_install(new_lib, remote_package[["gh_repo"]], { #nolint: nonportable_path_linter
-      with_local_install(newer_lib, remote_package[["gh_repo_old"]], { #nolint: nonportable_path_linter
+    with_local_install(new_lib, remote_package[["gh_repo"]], {
+      with_local_install(newer_lib, remote_package[["gh_repo_old"]], {
         package_info <- get_individual_package_info(remote_package[["name"]])
         expect_package_info(
           package_info,
@@ -468,7 +468,9 @@ test_that("get_individual_package_info gets correct libpath and version of multi
           version_identical = remote_package[["old_version"]],
           repository_match = NA_character_,
           remotetype_identical = "github",
-          remotepkgref_match = paste0("^", remote_package[["gh_repo_old"]], "$"),
+          remotepkgref_match = paste0(
+            "^", remote_package[["gh_repo_old"]], "$"
+          ),
           remoteref_identical = "28c716f",
           remotesha_identical = remote_package[["old_sha"]]
         )
@@ -490,7 +492,7 @@ test_that("get_individual_package_info gets correct libpath for lower search pri
   testthat::skip_if_offline()
   new_lib <- normalizePath(withr::local_tempdir())
   newer_lib <- normalizePath(withr::local_tempdir())
-  with_local_install(new_lib, remote_package[["gh_repo"]], { #nolint: nonportable_path_linter
+  with_local_install(new_lib, remote_package[["gh_repo"]], {
     with_local_install(newer_lib, "digest", {
       package_info <- get_individual_package_info(remote_package[["name"]])
       expect_package_info(
@@ -499,7 +501,7 @@ test_that("get_individual_package_info gets correct libpath for lower search pri
         version_identical = remote_package[["version"]],
         repository_match = NA_character_,
         remotetype_identical = "github",
-        remotepkgref_match = paste0("^", remote_package[["gh_repo"]], "$"), #nolint: nonportable_path_linter
+        remotepkgref_match = paste0("^", remote_package[["gh_repo"]], "$"),
         remoteref_identical = "HEAD",
         remotesha_identical = remote_package[["sha"]]
       )

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -271,7 +271,7 @@ test_that("get_individual_package_info collects information for packages loaded 
     path = dest_dir,
     verbose = FALSE
   )
-  loaded <- pkgload::load_all(dest_dir, quiet = TRUE)
+  loaded <- pkgload::load_all(dest_dir, quiet = TRUE, compile = FALSE)
   withr::defer({
     pkgload::unload(package = "rmini")
   })
@@ -324,7 +324,7 @@ test_that("get_individual_package_info collects information for packages loaded 
     path = dest_dir,
     verbose = FALSE
   )
-  loaded <- devtools::load_all(dest_dir, quiet = TRUE)
+  loaded <- devtools::load_all(dest_dir, quiet = TRUE, compile = FALSE)
   withr::defer({
     devtools::unload(package = "rmini")
   })

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -213,7 +213,23 @@ test_that("get_individual_package_info collects information for local packages c
       remotetype_identical = "local",
       remotepkgref_match = paste0("^local::", dest_dir, "$"),
       remoteref_identical = NA_character_,
-      remotesha_identical = NA_character_
+      remotesha_identical = NA_character_,
+      git = list(
+        repo = normalizePath(dest_dir),
+        is_git = TRUE,
+        commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+        clean = TRUE,
+        branch = list(
+          name = "master",
+          commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2",
+          upstream = "refs/remotes/origin/master", #nolint: nonportable_path_linter
+          remote_url = "https://github.com/yihui/rmini.git",
+          up_to_date = TRUE,
+          upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
+          ),
+        changed_files = list(),
+        tags = list()
+      )
     )
     expect_identical(
       package_info[["library"]],

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -377,6 +377,7 @@ test_that("get_individual_package_info collects information for altered packages
     path = dest_dir,
     verbose = FALSE
   )
+  testing_git_config(repo = dest_dir)
   test_file <- file.path(dest_dir, "foo.txt")
   writeLines("Hello, world!", con = test_file)
   gert::git_add(files = basename(test_file), repo = normalizePath(dest_dir))

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -329,7 +329,12 @@ test_that("get_individual_package_info collects information for packages loaded 
     path = dest_dir,
     verbose = FALSE
   )
-  loaded <- devtools::load_all(dest_dir, quiet = TRUE)
+  withr::with_envvar(
+    c("_R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_" = FALSE),
+    {
+      loaded <- devtools::load_all(dest_dir, quiet = TRUE)
+    }
+  )
   withr::defer({
     devtools::unload(package = "rmini")
   })
@@ -388,7 +393,12 @@ test_that("get_individual_package_info collects information for altered packages
   gert::git_add(files = basename(test_file), repo = normalizePath(dest_dir))
   commit_sha <- gert::git_commit(repo = dest_dir, message = "Initial commit")
   writeLines("Hello, testing!", con = test_file)
-  loaded <- devtools::load_all(dest_dir, quiet = TRUE)
+  withr::with_envvar(
+    c("_R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_" = FALSE),
+    {
+      loaded <- devtools::load_all(dest_dir, quiet = TRUE)
+    }
+  )
   withr::defer({
     devtools::unload(package = "rmini")
   })

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -226,7 +226,7 @@ test_that("get_individual_package_info collects information for local packages c
           remote_url = "https://github.com/yihui/rmini.git",
           up_to_date = TRUE,
           upstream_commit = "f839b7327c4cb422705b9f3b7c5ffc87555d98e2"
-          ),
+        ),
         changed_files = list(),
         tags = list()
       )
@@ -414,7 +414,7 @@ test_that("get_individual_package_info collects information for altered packages
           ),
           changed_files = list(
             foo.txt = "modified"
-            ),
+          ),
           tags = list()
         )
       )

--- a/tests/testthat/test-get_individual_package_info.R
+++ b/tests/testthat/test-get_individual_package_info.R
@@ -271,7 +271,12 @@ test_that("get_individual_package_info collects information for packages loaded 
     path = dest_dir,
     verbose = FALSE
   )
-  loaded <- pkgload::load_all(dest_dir, quiet = TRUE, compile = FALSE)
+  withr::with_envvar(
+    c("_R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_" = FALSE),
+    {
+      loaded <- pkgload::load_all(dest_dir, quiet = TRUE)
+    }
+  )
   withr::defer({
     pkgload::unload(package = "rmini")
   })
@@ -324,7 +329,7 @@ test_that("get_individual_package_info collects information for packages loaded 
     path = dest_dir,
     verbose = FALSE
   )
-  loaded <- devtools::load_all(dest_dir, quiet = TRUE, compile = FALSE)
+  loaded <- devtools::load_all(dest_dir, quiet = TRUE)
   withr::defer({
     devtools::unload(package = "rmini")
   })

--- a/tests/testthat/test-get_package_info.R
+++ b/tests/testthat/test-get_package_info.R
@@ -75,7 +75,8 @@ test_that("get_package_info outputs correct structure for defaults", {
                         "remotetype",
                         "remotepkgref",
                         "remoteref",
-                        "remotesha"
+                        "remotesha",
+                        "git"
                       )
                     )
                   },

--- a/tests/testthat/test-is_git_path.R
+++ b/tests/testthat/test-is_git_path.R
@@ -57,19 +57,3 @@ test_that("is_git_path processes file in git-repo correctly", {
   saveRDS(mtcars, test_file)
   expect_true(is_git_path(path = test_file))
 })
-
-
-
-# # TESTS BEGIN
-# test_that("get_git_info processes simple git-repo correctly", {
-#   test_dir <- withr::local_tempdir()
-#   gert::git_init(repo = test_dir)
-#   metadata <- get_file_metadata(csv_file)
-#   expect_identical(
-#     metadata,
-#     list(
-#       csv_metadata
-#     )
-#   )
-# })
-

--- a/tests/testthat/test-is_git_path.R
+++ b/tests/testthat/test-is_git_path.R
@@ -1,0 +1,75 @@
+## save current settings so that we can reset later
+threshold <- logger::log_threshold()
+appender  <- logger::log_appender()
+layout    <- logger::log_layout()
+on.exit({
+  ## reset logger settings
+  logger::log_threshold(threshold)
+  logger::log_layout(layout)
+  logger::log_appender(appender)
+})
+
+logger::log_appender(logger::appender_stdout)
+logger::log_threshold(logger::FATAL)
+logger::log_layout(logger::layout_simple)
+
+# # TESTS BEGIN
+test_that("is_git_path processes non-existing directory correctly", {
+  test_dir <- withr::local_tempdir()
+  test_dir_child <- file.path(test_dir, "child")
+  expect_error(
+    object = is_git_path(path = test_dir_child),
+    regexp = "^Cannot find git information for path which does not exist.$"
+  )
+})
+
+test_that("is_git_path processes non-existing file correctly", {
+  test_dir <- withr::local_tempdir()
+  test_file <- withr::local_tempfile(tmpdir = test_dir, fileext = ".rds")
+  expect_error(
+    object = is_git_path(path = test_file),
+    regexp = "^Cannot find git information for path which does not exist.$"
+  )
+})
+
+test_that("is_git_path processes non-git-repo correctly", {
+  test_dir <- withr::local_tempdir()
+  expect_false(is_git_path(path = test_dir))
+})
+
+test_that("is_git_path processes file in non-git-repo correctly", {
+  test_dir <- withr::local_tempdir()
+  test_file <- withr::local_tempfile(tmpdir = test_dir, fileext = ".rds")
+  saveRDS(mtcars, test_file)
+  expect_false(is_git_path(path = test_file))
+})
+
+test_that("is_git_path processes git-repo correctly", {
+  test_dir <- withr::local_tempdir()
+  gert::git_init(path = test_dir)
+  expect_true(is_git_path(path = test_dir))
+})
+
+test_that("is_git_path processes file in git-repo correctly", {
+  test_dir <- withr::local_tempdir()
+  gert::git_init(path = test_dir)
+  test_file <- withr::local_tempfile(tmpdir = test_dir, fileext = ".rds")
+  saveRDS(mtcars, test_file)
+  expect_true(is_git_path(path = test_file))
+})
+
+
+
+# # TESTS BEGIN
+# test_that("get_git_info processes simple git-repo correctly", {
+#   test_dir <- withr::local_tempdir()
+#   gert::git_init(repo = test_dir)
+#   metadata <- get_file_metadata(csv_file)
+#   expect_identical(
+#     metadata,
+#     list(
+#       csv_metadata
+#     )
+#   )
+# })
+


### PR DESCRIPTION
Another PR towards the manifest export

this one adds utilities for identifying git status on a directory, and surfacing any changes from upstream or local HEAD (dirty repo).

Notable updates:
* adds `get_git_info` which returns a list with git info about a repo specified
* Adds a call to `get_git_info` to `get_individual_package_info` for packages installed from local directory or loaded with devtools/pkgload