### PR TITLE
Fixes found during integration with `workflow.pacta`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.workflow.utils
 Title: Utility functions for PACTA workflows
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/parse_json_params.R
+++ b/R/parse_json_params.R
@@ -4,7 +4,7 @@ parse_params <- function(
   schema_file = NULL
 ) {
   log_trace("Parsing params.")
-  if (file.exists(json)) {
+  if (length(json) == 1L && file.exists(json)) {
     log_trace("Reading params from file: {json}.}")
   } else {
     log_trace("Reading params from string.")

--- a/R/parse_json_params.R
+++ b/R/parse_json_params.R
@@ -21,7 +21,8 @@ parse_params <- function(
       validation_results <- jsonvalidate::json_validate(
         json = jsonlite::toJSON(full_params, auto_unbox = TRUE),
         schema = schema_file,
-        verbose = TRUE
+        verbose = TRUE,
+        engine = "ajv"
       )
       if (validation_results) {
         log_trace("Validation successful.")


### PR DESCRIPTION
Fixes found while working on https://github.com/RMI-PACTA/workflow.pacta/pull/64

* [0718c4c](https://github.com/RMI-PACTA/pacta.workflow.utils/pull/13/commits/0718c4cc4dea5cda2e32ecf9ad4a8501a15686f6): Handling for JSON strings that are read in as character vectors, rather than single strings. The `file.exists` check for reading from file was erroring when the `json` object had length greater than 1.