### PR TITLE
Add (default FALSE) option to include summary info

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -19,4 +19,4 @@ name: R
 jobs:
   R-package:
     name: R Package Checks
-    uses: RMI-PACTA/actions/.github/workflows/R.yml@main
+    uses: RMI-PACTA/actions/.github/workflows/R.yml@always-codecov

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -20,3 +20,4 @@ jobs:
   R-package:
     name: R Package Checks
     uses: RMI-PACTA/actions/.github/workflows/R.yml@always-codecov
+    secrets: inherit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.workflow.utils
 Title: Utility functions for PACTA workflows
-Version: 0.0.0.9006
+Version: 0.0.0.9007
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/export_manifest.R
+++ b/R/export_manifest.R
@@ -17,14 +17,16 @@ export_manifest <- function(
   input_files,
   output_files,
   params,
-  ...
+  ...,
+  file_summary_info = FALSE
 ) {
 
   manifest_list <- create_manifest(
     input_files = input_files,
     output_files = output_files,
     params = params,
-    ...
+    ...,
+    file_summary_info = file_summary_info
   )
 
   manifest_json <- jsonlite::toJSON(
@@ -46,7 +48,8 @@ export_manifest <- function(
 create_manifest <- function(
   input_files,
   output_files,
-  ...
+  ...,
+  file_summary_info = FALSE
 ) {
   log_debug("Creating metadata manifest")
   log_trace("Checking ... arguments")
@@ -55,8 +58,14 @@ create_manifest <- function(
     clean_args <- check_arg_type(args_list)
   }
   manifest_list <- list(
-    input_files = get_file_metadata(input_files),
-    output_files = get_file_metadata(output_files),
+    input_files = get_file_metadata(
+      input_files,
+      summary_info = file_summary_info
+    ),
+    output_files = get_file_metadata(
+      output_files,
+      summary_info = file_summary_info
+    ),
     envirionment = get_manifest_envirionment_info(),
     manifest_creation_datetime = format.POSIXct(
       x = Sys.time(),

--- a/R/export_manifest.R
+++ b/R/export_manifest.R
@@ -6,7 +6,9 @@
 #' @param output_files List or vector (named or unnamed) of files that are
 #' outputs from the workflow. Passed to `[get_file_metadata()]`.
 #' @param params List parameters used to define the workflow.
-#' @param ... Nested list to be included in manifest. Passed on to
+#' @param ... Nested (named) lists to be included in manifest. Passed on to
+#' @param file_summary_info Logical. If `TRUE`, include file summary
+#' information.
 #' `create_manifest`.
 #'
 #' @return (invisible) JSON string with metadata manifest.

--- a/R/get_file_metadata.R
+++ b/R/get_file_metadata.R
@@ -114,6 +114,8 @@ get_single_file_metadata <- function(
     if (exists("summary_info")) {
       file_metadata[["summary_info"]] <- summary_info
     }
+  } else {
+    logger::log_trace("Skipping summary information for file: \"{filepath}\".")
   }
 
   return(file_metadata)

--- a/R/get_file_metadata.R
+++ b/R/get_file_metadata.R
@@ -4,12 +4,21 @@
 #' details, suitable for inclusion in manifest export.
 #'
 #' @param filepaths vector of filepaths
+#' @param summary_info logical, whether to include summary information
+#' (nrow/length, colnames/names, class)
 #'
 #' @return nested list of file details, length the same as the input vector.
-get_file_metadata <- function(filepaths) {
+get_file_metadata <- function(
+  filepaths,
+  summary_info = FALSE
+) {
   logger::log_trace("Getting metadata for files.")
 
-  file_metadata <- lapply(filepaths, get_single_file_metadata)
+  file_metadata <- lapply(
+    filepaths,
+    get_single_file_metadata,
+    summary_info = summary_info
+  )
 
   return(file_metadata)
 }
@@ -20,9 +29,14 @@ get_file_metadata <- function(filepaths) {
 #' details, suitable for inclusion in manifest export.
 #'
 #' @param filepath vector of filepaths
+#' @param summary_info logical, whether to include summary information
+#' (nrow/length, colnames/names, class)
 #'
 #' @return list of file details
-get_single_file_metadata <- function(filepath) {
+get_single_file_metadata <- function(
+  filepath,
+  summary_info = FALSE
+) {
   if (length(filepath) > 1L) {
     logger::log_error("get_single_file_metadata only accepts single files.")
     stop("Only one file path can be passed to get_single_file_metadata.")
@@ -59,45 +73,47 @@ get_single_file_metadata <- function(filepath) {
     file_md5 = file_md5
   )
 
-  logger::log_trace("Getting summary information for file: \"{filepath}\".")
-  if (tolower(tools::file_ext(filepath)) == "rds") {
-    contents <- readRDS(filepath)
-  } else if (tolower(tools::file_ext(filepath)) == "csv") {
-    contents <- utils::read.csv(filepath)
-  } else if (tolower(tools::file_ext(filepath)) == "json") {
-    contents <- jsonlite::fromJSON(filepath)
-  } else {
-    logger::log_trace(
-      "File not supported for summary information: \"{filepath}\"."
-    )
-    contents <- NULL
-  }
-  # expecting a data.frame for output files
-  if (inherits(contents, "data.frame")) {
-    summary_info <- list(
-      nrow = nrow(contents),
-      colnames = colnames(contents),
-      class = class(contents)
-    )
-  } else if (inherits(contents, "list")) {
-    summary_info <- list(
-      length = length(contents),
-      names = names(contents),
-      class = class(contents)
-    )
-  } else if (!is.null(contents)) {
-    logger::log_trace(
-      "Only data.frame and list objects supported for summary information."
-    )
-    summary_info <- list(
-      class = class(contents)
-    )
-  } else {
-    summary_info <- NULL
-  }
+  if (summary_info) {
+    logger::log_trace("Getting summary information for file: \"{filepath}\".")
+    if (tolower(tools::file_ext(filepath)) == "rds") {
+      contents <- readRDS(filepath)
+    } else if (tolower(tools::file_ext(filepath)) == "csv") {
+      contents <- utils::read.csv(filepath)
+    } else if (tolower(tools::file_ext(filepath)) == "json") {
+      contents <- jsonlite::fromJSON(filepath)
+    } else {
+      logger::log_trace(
+        "File not supported for summary information: \"{filepath}\"."
+      )
+      contents <- NULL
+    }
+    # expecting a data.frame for output files
+    if (inherits(contents, "data.frame")) {
+      summary_info <- list(
+        nrow = nrow(contents),
+        colnames = colnames(contents),
+        class = class(contents)
+      )
+    } else if (inherits(contents, "list")) {
+      summary_info <- list(
+        length = length(contents),
+        names = names(contents),
+        class = class(contents)
+      )
+    } else if (!is.null(contents)) {
+      logger::log_trace(
+        "Only data.frame and list objects supported for summary information."
+      )
+      summary_info <- list(
+        class = class(contents)
+      )
+    } else {
+      summary_info <- NULL
+    }
 
-  if (exists("summary_info")) {
-    file_metadata[["summary_info"]] <- summary_info
+    if (exists("summary_info")) {
+      file_metadata[["summary_info"]] <- summary_info
+    }
   }
 
   return(file_metadata)

--- a/man/export_manifest.Rd
+++ b/man/export_manifest.Rd
@@ -4,7 +4,14 @@
 \alias{export_manifest}
 \title{Export manifest file with metadata}
 \usage{
-export_manifest(manifest_path, input_files, output_files, params, ...)
+export_manifest(
+  manifest_path,
+  input_files,
+  output_files,
+  params,
+  ...,
+  file_summary_info = FALSE
+)
 }
 \arguments{
 \item{manifest_path}{Path to the manifest file.}
@@ -17,7 +24,10 @@ outputs from the workflow. Passed to \verb{[get_file_metadata()]}.}
 
 \item{params}{List parameters used to define the workflow.}
 
-\item{...}{Nested list to be included in manifest. Passed on to
+\item{...}{Nested (named) lists to be included in manifest. Passed on to}
+
+\item{file_summary_info}{Logical. If \code{TRUE}, include file summary
+information.
 \code{create_manifest}.}
 }
 \value{

--- a/man/get_file_metadata.Rd
+++ b/man/get_file_metadata.Rd
@@ -4,10 +4,13 @@
 \alias{get_file_metadata}
 \title{Get Metadata for a vector of filepaths}
 \usage{
-get_file_metadata(filepaths)
+get_file_metadata(filepaths, summary_info = FALSE)
 }
 \arguments{
 \item{filepaths}{vector of filepaths}
+
+\item{summary_info}{logical, whether to include summary information
+(nrow/length, colnames/names, class)}
 }
 \value{
 nested list of file details, length the same as the input vector.

--- a/man/get_single_file_metadata.Rd
+++ b/man/get_single_file_metadata.Rd
@@ -4,10 +4,13 @@
 \alias{get_single_file_metadata}
 \title{Get Metadata for a file}
 \usage{
-get_single_file_metadata(filepath)
+get_single_file_metadata(filepath, summary_info = FALSE)
 }
 \arguments{
 \item{filepath}{vector of filepaths}
+
+\item{summary_info}{logical, whether to include summary information
+(nrow/length, colnames/names, class)}
 }
 \value{
 list of file details

--- a/tests/testthat/test-create_manifest.R
+++ b/tests/testthat/test-create_manifest.R
@@ -87,7 +87,8 @@ test_that("create_manifest with works with simple file arguments", {
   suppressWarnings({
     manifest <- create_manifest(
       input_files = csv_file,
-      output_files = csv_file
+      output_files = csv_file,
+      file_summary_info = TRUE
     )
   })
 
@@ -163,7 +164,8 @@ test_that("create_manifest with works with vector file arguments", {
   suppressWarnings({
     manifest <- create_manifest(
       input_files = c(csv_file, rds_file),
-      output_files = c(csv_file, rds_file)
+      output_files = c(csv_file, rds_file),
+      file_summary_info = TRUE
     )
   })
 
@@ -239,7 +241,8 @@ test_that("create_manifest with works with named vector file arguments", {
   suppressWarnings({
     manifest <- create_manifest(
       input_files = c(foo = csv_file, bar = rds_file),
-      output_files = NULL
+      output_files = NULL,
+      file_summary_info = TRUE
     )
   })
 
@@ -315,7 +318,8 @@ test_that("create_manifest with works with named list file arguments", {
   suppressWarnings({
     manifest <- create_manifest(
       input_files = list(foo = csv_file, bar = rds_file),
-      output_files = NULL
+      output_files = NULL,
+      file_summary_info = TRUE
     )
   })
 
@@ -344,7 +348,8 @@ test_that("create_manifest works with simple ... arguments", {
     manifest <- create_manifest(
       input_files = NULL,
       output_files = NULL,
-      params = list(foo = "bar")
+      params = list(foo = "bar"),
+      file_summary_info = TRUE
     )
   })
   expect_type(manifest, "list")
@@ -376,7 +381,8 @@ test_that("create_manifest works with nested ... arguments", {
           quux = 3.14159
         ),
         grault = "garply"
-      )
+      ),
+      file_summary_info = TRUE
     )
   })
   expect_type(manifest, "list")

--- a/tests/testthat/test-create_manifest.R
+++ b/tests/testthat/test-create_manifest.R
@@ -77,6 +77,53 @@ test_that("create_manifest with works with simple file arguments", {
       as.POSIXlt(file.mtime(csv_file), tz = "UTC"),
       "%Y-%m-%dT%H:%M:%S+00:00"
     ),
+    file_md5 = digest::digest(file = csv_file, algo = "md5")
+  )
+
+  suppressWarnings({
+    manifest <- create_manifest(
+      input_files = csv_file,
+      output_files = csv_file
+    )
+  })
+
+  expect_type(manifest, "list")
+  expect_named(
+    object = manifest,
+    expected = c(
+      "input_files",
+      "output_files",
+      "envirionment",
+      "manifest_creation_datetime"
+    )
+  )
+  expect_identical(
+    object = manifest[["input_files"]],
+    expected = list(csv_info)
+  )
+  expect_identical(
+    object = manifest[["output_files"]],
+    expected = list(csv_info)
+  )
+})
+
+test_that("create_manifest with works with simple file arguments and summary", {
+  csv_file <- withr::local_tempfile(fileext = ".csv")
+  write.csv(mtcars, csv_file, row.names = FALSE)
+  csv_info <- list(
+    file_name = basename(csv_file),
+    file_extension = "csv",
+    file_path = csv_file,
+    file_size_human = format(
+      structure(as.integer(file.size(csv_file)), class = "object_size"), # nolint: undesirable_function_linter
+      units = "auto",
+      standard = "SI"
+    ),
+    file_size = as.integer(file.size(csv_file)),
+    file_last_modified = format(
+      as.POSIXlt(file.mtime(csv_file), tz = "UTC"),
+      "%Y-%m-%dT%H:%M:%S+00:00"
+    ),
     file_md5 = digest::digest(file = csv_file, algo = "md5"),
     summary_info = list(
       nrow = nrow(mtcars),

--- a/tests/testthat/test-create_manifest.R
+++ b/tests/testthat/test-create_manifest.R
@@ -17,7 +17,8 @@ test_that("create_manifest with minimal arguments", {
   suppressWarnings({
     manifest <- create_manifest(
       input_files = NULL,
-      output_files = NULL
+      output_files = NULL,
+      file_summary_info = TRUE
     )
     expected_environment_info <- get_manifest_envirionment_info()
   })

--- a/tests/testthat/test-export_manifest.R
+++ b/tests/testthat/test-export_manifest.R
@@ -20,6 +20,65 @@ test_that("export_manifest with minimal arguments", {
       manifest_path = manifest_file,
       input_files = NULL,
       output_files = NULL,
+      params = list()
+    )
+  })
+
+  expect_true(file.exists(manifest_file))
+  expect_gt(file.size(manifest_file), 0L)
+  manifest_content <- jsonlite::fromJSON(txt = manifest_file)
+  creation_time <- as.POSIXct(Sys.time(), tz = "UTC")
+  attr(creation_time, "tzone") <- "UTC"
+  expect_type(manifest_content, "list")
+  expect_named(
+    object = manifest_content,
+    expected = c(
+      "input_files",
+      "output_files",
+      "envirionment",
+      "manifest_creation_datetime",
+      "params"
+    )
+  )
+  expect_identical(
+    object = manifest_content[["input_files"]],
+    expected = list()
+  )
+  expect_identical(
+    object = manifest_content[["output_files"]],
+    expected = list()
+  )
+  expect_equal(
+    object = as.POSIXct(
+      manifest_content[["manifest_creation_datetime"]],
+      tz = "UTC"
+    ),
+    expected = creation_time,
+    tolerance = 1L
+  )
+  expect_identical(
+    object = manifest_content[["params"]],
+    expected = list()
+  )
+  # loaded packages can change during testthat testing
+  expected_environment_info <- suppressWarnings({
+    get_manifest_envirionment_info()
+  })
+  expected_environment_info[["packages"]][["loaded"]] <- list()
+  manifest_content[["envirionment"]][["packages"]][["loaded"]] <- list()
+  expect_identical(
+    object = manifest_content[["envirionment"]],
+    expected = expected_environment_info
+  )
+})
+
+test_that("export_manifest with minimal arguments and file summary info", {
+  manifest_file <- withr::local_tempfile(fileext = ".json")
+  suppressWarnings({
+    manifest <- export_manifest(
+      manifest_path = manifest_file,
+      input_files = NULL,
+      output_files = NULL,
       params = list(),
       file_summary_info = TRUE
     )
@@ -72,3 +131,186 @@ test_that("export_manifest with minimal arguments", {
     expected = expected_environment_info
   )
 })
+
+# setup
+test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+
+csv_file <- withr::local_tempfile(fileext = ".csv")
+write.csv(mtcars, csv_file, row.names = FALSE)
+Sys.setFileTime(csv_file, test_time)
+csv_metadata <- list(
+  file_name = basename(csv_file),
+  file_extension = "csv",
+  file_path = csv_file,
+  file_size_human = format(
+    structure(as.integer(file.size(csv_file)), class = "object_size"), # nolint: undesirable_function_linter
+    units = "auto",
+    standard = "SI"
+  ),
+  file_size = as.integer(file.size(csv_file)),
+  file_last_modified = format(
+    as.POSIXlt(test_time, tz = "UTC"),
+    "%Y-%m-%dT%H:%M:%S+00:00"
+  ),
+  file_md5 = digest::digest(csv_file, algo = "md5", file = TRUE)
+)
+csv_metadata_summary <- c(
+  csv_metadata,
+  list(
+    summary_info = list(
+      nrow = 32L,
+      colnames = colnames(mtcars),
+      class = "data.frame"
+    )
+  )
+)
+
+rds_file <- withr::local_tempfile(fileext = ".rds")
+saveRDS(mtcars, rds_file)
+Sys.setFileTime(rds_file, test_time)
+rds_metadata <- list(
+  file_name = basename(rds_file),
+  file_extension = "rds",
+  file_path = rds_file,
+  file_size_human = format(
+    structure(as.integer(file.size(rds_file)), class = "object_size"),# nolint: undesirable_function_linter
+    units = "auto",
+    standard = "SI"
+  ),
+  file_size = as.integer(file.size(rds_file)),
+  file_last_modified = format(
+    as.POSIXlt(test_time, tz = "UTC"),
+    "%Y-%m-%dT%H:%M:%S+00:00"
+  ),
+  file_md5 = digest::digest(rds_file, algo = "md5", file = TRUE)
+)
+rds_metadata_summary <- c(
+  rds_metadata,
+  list(
+    summary_info = list(
+      nrow = 32L,
+      colnames = colnames(mtcars),
+      class = "data.frame"
+    )
+  )
+)
+
+test_that("export_manifest with files with summary info", {
+  manifest_file <- withr::local_tempfile(fileext = ".json")
+  suppressWarnings({
+    manifest <- export_manifest(
+      manifest_path = manifest_file,
+      input_files = csv_file,
+      output_files = rds_file,
+      params = list(),
+      file_summary_info = TRUE
+    )
+  })
+
+  expect_true(file.exists(manifest_file))
+  expect_gt(file.size(manifest_file), 0L)
+  manifest_content <- jsonlite::fromJSON(txt = manifest_file, simplifyDataFrame = FALSE)
+  creation_time <- as.POSIXct(Sys.time(), tz = "UTC")
+  attr(creation_time, "tzone") <- "UTC"
+  expect_type(manifest_content, "list")
+  expect_named(
+    object = manifest_content,
+    expected = c(
+      "input_files",
+      "output_files",
+      "envirionment",
+      "manifest_creation_datetime",
+      "params"
+    )
+  )
+  expect_identical(
+    object = manifest_content[["input_files"]][[1L]],
+    expected = csv_metadata_summary
+  )
+  expect_identical(
+    object = manifest_content[["output_files"]][[1L]],
+    expected = rds_metadata_summary
+  )
+  expect_equal(
+    object = as.POSIXct(
+      manifest_content[["manifest_creation_datetime"]],
+      tz = "UTC"
+    ),
+    expected = creation_time,
+    tolerance = 1L
+  )
+  expect_identical(
+    object = manifest_content[["params"]],
+    expected = list()
+  )
+  # loaded packages can change during testthat testing
+  expected_environment_info <- suppressWarnings({
+    get_manifest_envirionment_info()
+  })
+  expected_environment_info[["packages"]][["loaded"]] <- list()
+  manifest_content[["envirionment"]][["packages"]][["loaded"]] <- list()
+  expect_identical(
+    object = manifest_content[["envirionment"]],
+    expected = expected_environment_info
+  )
+})
+
+test_that("export_manifest with files", {
+  manifest_file <- withr::local_tempfile(fileext = ".json")
+  suppressWarnings({
+    manifest <- export_manifest(
+      manifest_path = manifest_file,
+      input_files = csv_file,
+      output_files = rds_file,
+      params = list()
+    )
+  })
+
+  expect_true(file.exists(manifest_file))
+  expect_gt(file.size(manifest_file), 0L)
+  manifest_content <- jsonlite::fromJSON(txt = manifest_file)
+  creation_time <- as.POSIXct(Sys.time(), tz = "UTC")
+  attr(creation_time, "tzone") <- "UTC"
+  expect_type(manifest_content, "list")
+  expect_named(
+    object = manifest_content,
+    expected = c(
+      "input_files",
+      "output_files",
+      "envirionment",
+      "manifest_creation_datetime",
+      "params"
+    )
+  )
+  expect_identical(
+    object = as.list(manifest_content[["input_files"]]),
+    expected = csv_metadata
+  )
+  expect_identical(
+    object = as.list(manifest_content[["output_files"]]),
+    expected = rds_metadata
+  )
+  expect_equal(
+    object = as.POSIXct(
+      manifest_content[["manifest_creation_datetime"]],
+      tz = "UTC"
+    ),
+    expected = creation_time,
+    tolerance = 1L
+  )
+  expect_identical(
+    object = manifest_content[["params"]],
+    expected = list()
+  )
+  # loaded packages can change during testthat testing
+  expected_environment_info <- suppressWarnings({
+    get_manifest_envirionment_info()
+  })
+  expected_environment_info[["packages"]][["loaded"]] <- list()
+  manifest_content[["envirionment"]][["packages"]][["loaded"]] <- list()
+  expect_identical(
+    object = manifest_content[["envirionment"]],
+    expected = expected_environment_info
+  )
+})
+

--- a/tests/testthat/test-export_manifest.R
+++ b/tests/testthat/test-export_manifest.R
@@ -20,7 +20,8 @@ test_that("export_manifest with minimal arguments", {
       manifest_path = manifest_file,
       input_files = NULL,
       output_files = NULL,
-      params = list()
+      params = list(),
+      file_summary_info = TRUE
     )
   })
 

--- a/tests/testthat/test-export_manifest.R
+++ b/tests/testthat/test-export_manifest.R
@@ -209,7 +209,10 @@ test_that("export_manifest with files with summary info", {
 
   expect_true(file.exists(manifest_file))
   expect_gt(file.size(manifest_file), 0L)
-  manifest_content <- jsonlite::fromJSON(txt = manifest_file, simplifyDataFrame = FALSE)
+  manifest_content <- jsonlite::fromJSON(
+    txt = manifest_file,
+    simplifyDataFrame = FALSE
+  )
   creation_time <- as.POSIXct(Sys.time(), tz = "UTC")
   attr(creation_time, "tzone") <- "UTC"
   expect_type(manifest_content, "list")
@@ -313,4 +316,3 @@ test_that("export_manifest with files", {
     expected = expected_environment_info
   )
 })
-

--- a/tests/testthat/test-get_file_metadata.R
+++ b/tests/testthat/test-get_file_metadata.R
@@ -130,7 +130,7 @@ test_that("get_file_metadata processes a vector of files with summary", {
 
 test_that("get_file_metadata processes a list of files correctly", {
   metadata <- get_file_metadata(
-    list(csv_file, rds_file),
+    list(csv_file, rds_file)
   )
   expect_identical(
     metadata,

--- a/tests/testthat/test-get_file_metadata.R
+++ b/tests/testthat/test-get_file_metadata.R
@@ -78,50 +78,65 @@ rds_metadata_summary <- c(
 
 # TESTS BEGIN
 test_that("get_file_metadata processes single files correctly", {
-  metadata <- get_file_metadata(csv_file)
+  metadata <- get_file_metadata(
+    csv_file,
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list(
-      csv_metadata
+      csv_metadata_summary
     )
   )
 })
 
 test_that("get_file_metadata processes a vector of files correctly", {
-  metadata <- get_file_metadata(c(csv_file, rds_file))
+  metadata <- get_file_metadata(
+    c(csv_file, rds_file),
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list(
-      csv_metadata,
-      rds_metadata
+      csv_metadata_summary,
+      rds_metadata_summary
     )
   )
 })
 
 test_that("get_file_metadata processes a list of files correctly", {
-  metadata <- get_file_metadata(list(csv_file, rds_file))
+  metadata <- get_file_metadata(
+    list(csv_file, rds_file),
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list(
-      csv_metadata,
-      rds_metadata
+      csv_metadata_summary,
+      rds_metadata_summary
     )
   )
 })
 
 test_that("get_file_metadata respects input order", {
-  metadata <- get_file_metadata(c(rds_file, csv_file))
+  metadata <- get_file_metadata(
+    c(rds_file, csv_file),
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list(
-      rds_metadata,
-      csv_metadata
+      rds_metadata_summary,
+      csv_metadata_summary
     )
   )
 })
 
 test_that("get_file_metadata returns an empty list on empty input", {
-  metadata <- get_file_metadata(list())
+  metadata <- get_file_metadata(
+    list(),
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list()
@@ -129,7 +144,10 @@ test_that("get_file_metadata returns an empty list on empty input", {
 })
 
 test_that("get_file_metadata returns an empty list on NULL input", {
-  metadata <- get_file_metadata(NULL)
+  metadata <- get_file_metadata(
+    NULL,
+    summary_info = TRUE
+  )
   expect_identical(
     metadata,
     list()
@@ -144,7 +162,7 @@ test_that("missing files raise an error", {
   )
 })
 
-test_that("get_single_file_metadata without argument raises an error", {
+test_that("get_file_metadata without argument raises an error", {
   expect_error(
     object = get_file_metadata()
   )

--- a/tests/testthat/test-get_file_metadata.R
+++ b/tests/testthat/test-get_file_metadata.R
@@ -79,6 +79,17 @@ rds_metadata_summary <- c(
 # TESTS BEGIN
 test_that("get_file_metadata processes single files correctly", {
   metadata <- get_file_metadata(
+    csv_file
+  )
+  expect_identical(
+    metadata,
+    list(
+      csv_metadata
+    )
+  )
+})
+test_that("get_file_metadata processes single files with summary", {
+  metadata <- get_file_metadata(
     csv_file,
     summary_info = TRUE
   )
@@ -91,6 +102,19 @@ test_that("get_file_metadata processes single files correctly", {
 })
 
 test_that("get_file_metadata processes a vector of files correctly", {
+  metadata <- get_file_metadata(
+    c(csv_file, rds_file)
+  )
+  expect_identical(
+    metadata,
+    list(
+      csv_metadata,
+      rds_metadata
+    )
+  )
+})
+
+test_that("get_file_metadata processes a vector of files with summary", {
   metadata <- get_file_metadata(
     c(csv_file, rds_file),
     summary_info = TRUE
@@ -105,6 +129,19 @@ test_that("get_file_metadata processes a vector of files correctly", {
 })
 
 test_that("get_file_metadata processes a list of files correctly", {
+  metadata <- get_file_metadata(
+    list(csv_file, rds_file),
+  )
+  expect_identical(
+    metadata,
+    list(
+      csv_metadata,
+      rds_metadata
+    )
+  )
+})
+
+test_that("get_file_metadata processes a list of files with summary", {
   metadata <- get_file_metadata(
     list(csv_file, rds_file),
     summary_info = TRUE

--- a/tests/testthat/test-get_file_metadata.R
+++ b/tests/testthat/test-get_file_metadata.R
@@ -33,11 +33,16 @@ csv_metadata <- list(
     as.POSIXlt(test_time, tz = "UTC"),
     "%Y-%m-%dT%H:%M:%S+00:00"
   ),
-  file_md5 = digest::digest(csv_file, algo = "md5", file = TRUE),
-  summary_info = list(
-    nrow = 32L,
-    colnames = colnames(mtcars),
-    class = "data.frame"
+  file_md5 = digest::digest(csv_file, algo = "md5", file = TRUE)
+)
+csv_metadata_summary <- c(
+  csv_metadata,
+  list(
+    summary_info = list(
+      nrow = 32L,
+      colnames = colnames(mtcars),
+      class = "data.frame"
+    )
   )
 )
 
@@ -58,11 +63,16 @@ rds_metadata <- list(
     as.POSIXlt(test_time, tz = "UTC"),
     "%Y-%m-%dT%H:%M:%S+00:00"
   ),
-  file_md5 = digest::digest(rds_file, algo = "md5", file = TRUE),
-  summary_info = list(
-    nrow = 32L,
-    colnames = colnames(mtcars),
-    class = "data.frame"
+  file_md5 = digest::digest(rds_file, algo = "md5", file = TRUE)
+)
+rds_metadata_summary <- c(
+  rds_metadata,
+  list(
+    summary_info = list(
+      nrow = 32L,
+      colnames = colnames(mtcars),
+      class = "data.frame"
+    )
   )
 )
 

--- a/tests/testthat/test-get_single_file_metadata.R
+++ b/tests/testthat/test-get_single_file_metadata.R
@@ -18,6 +18,33 @@ test_that("get_single_file_metadata processes CSV tables correctly", {
   write.csv(mtcars, testfile, row.names = FALSE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "csv",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes CSV tables with summary info", {
+  testfile <- withr::local_tempfile(fileext = ".csv")
+  write.csv(mtcars, testfile, row.names = FALSE)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
   metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
@@ -46,6 +73,33 @@ test_that("get_single_file_metadata processes CSV tables correctly", {
 })
 
 test_that("get_single_file_metadata processes RDS tables correctly", {
+  testfile <- withr::local_tempfile(fileext = ".rds")
+  saveRDS(mtcars, testfile)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "rds",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes RDS tables with summary info", {
   testfile <- withr::local_tempfile(fileext = ".rds")
   saveRDS(mtcars, testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
@@ -82,6 +136,33 @@ test_that("get_single_file_metadata processes RDS non-tables correctly", {
   saveRDS("This is a string", testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "rds",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes RDS non-tables with summary", {
+  testfile <- withr::local_tempfile(fileext = ".rds")
+  saveRDS("This is a string", testfile)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
   metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
@@ -103,6 +184,34 @@ test_that("get_single_file_metadata processes RDS non-tables correctly", {
       summary_info = list(
         class = "character"
       )
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes txt files correctly", {
+  testfile <- withr::local_tempfile(fileext = ".txt")
+  writeLines("This is a string", testfile)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "txt",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+      # No summary info
     )
   )
 })
@@ -136,6 +245,41 @@ test_that("get_single_file_metadata processes txt files correctly", {
 })
 
 test_that("get_single_file_metadata processes lists RDS correctly", {
+  testfile <- withr::local_tempfile(fileext = ".rds")
+  test_list <- list(
+    a = 1L,
+    b = "two",
+    c = list(
+      d = 3.4,
+      e = "four"
+    )
+  )
+  saveRDS(test_list, testfile)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "rds",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes lists RDS with summary", {
   testfile <- withr::local_tempfile(fileext = ".rds")
   test_list <- list(
     a = 1L,
@@ -188,6 +332,41 @@ test_that("get_single_file_metadata processes named JSON list correctly", {
   jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "JSON",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes named JSON list with summary", {
+  testfile <- withr::local_tempfile(fileext = ".JSON")
+  test_list <- list(
+    a = 1L,
+    b = "two",
+    c = list(
+      d = 3.4,
+      e = "four"
+    )
+  )
+  jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
   metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
@@ -216,6 +395,41 @@ test_that("get_single_file_metadata processes named JSON list correctly", {
 })
 
 test_that("get_single_file_metadata processes unnamed JSON list correctly", {
+  testfile <- withr::local_tempfile(fileext = ".JSON")
+  test_list <- list(
+    1L,
+    "two",
+    list(
+      d = 3.4,
+      e = "four"
+    )
+  )
+  jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "JSON",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes unnamed JSON list with summary", {
   testfile <- withr::local_tempfile(fileext = ".JSON")
   test_list <- list(
     1L,
@@ -268,6 +482,41 @@ test_that("get_single_file_metadata processes partially named JSON", {
   jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "JSON",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata partially named JSON with summary", {
+  testfile <- withr::local_tempfile(fileext = ".JSON")
+  test_list <- list(
+    1L,
+    b = "two",
+    list(
+      d = 3.4,
+      e = "four"
+    )
+  )
+  jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
   metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
@@ -300,6 +549,33 @@ test_that("get_single_file_metadata processes JSON table correctly", {
   jsonlite::write_json(mtcars, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "JSON",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes JSON table with summary", {
+  testfile <- withr::local_tempfile(fileext = ".JSON")
+  jsonlite::write_json(mtcars, testfile, auto_unbox = TRUE)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
   metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
@@ -323,6 +599,34 @@ test_that("get_single_file_metadata processes JSON table correctly", {
         colnames = colnames(mtcars),
         class = "data.frame"
       )
+    )
+  )
+})
+
+test_that("get_single_file_metadata processes empty files correctly", {
+  testfile <- withr::local_tempfile(fileext = ".gitkeep")
+  file.create(testfile)
+  test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
+  Sys.setFileTime(testfile, test_time)
+  metadata <- get_single_file_metadata(testfile)
+  expect_identical(
+    metadata,
+    list(
+      file_name = basename(testfile),
+      file_extension = "gitkeep",
+      file_path = testfile,
+      file_size_human = format(
+        structure(as.integer(file.size(testfile)), class = "object_size"), # nolint: undesirable_function_linter
+        units = "auto",
+        standard = "SI"
+      ),
+      file_size = as.integer(file.size(testfile)),
+      file_last_modified = format(
+        as.POSIXlt(test_time, tz = "UTC"),
+        "%Y-%m-%dT%H:%M:%S+00:00"
+      ),
+      file_md5 = digest::digest(testfile, algo = "md5", file = TRUE)
+      # No summary info
     )
   )
 })

--- a/tests/testthat/test-get_single_file_metadata.R
+++ b/tests/testthat/test-get_single_file_metadata.R
@@ -18,7 +18,7 @@ test_that("get_single_file_metadata processes CSV tables correctly", {
   write.csv(mtcars, testfile, row.names = FALSE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -50,7 +50,7 @@ test_that("get_single_file_metadata processes RDS tables correctly", {
   saveRDS(mtcars, testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -82,7 +82,7 @@ test_that("get_single_file_metadata processes RDS non-tables correctly", {
   saveRDS("This is a string", testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -112,7 +112,7 @@ test_that("get_single_file_metadata processes txt files correctly", {
   writeLines("This is a string", testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -148,7 +148,7 @@ test_that("get_single_file_metadata processes lists RDS correctly", {
   saveRDS(test_list, testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -188,7 +188,7 @@ test_that("get_single_file_metadata processes named JSON list correctly", {
   jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -228,7 +228,7 @@ test_that("get_single_file_metadata processes unnamed JSON list correctly", {
   jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -268,7 +268,7 @@ test_that("get_single_file_metadata processes partially named JSON", {
   jsonlite::write_json(test_list, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -300,7 +300,7 @@ test_that("get_single_file_metadata processes JSON table correctly", {
   jsonlite::write_json(mtcars, testfile, auto_unbox = TRUE)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(
@@ -332,7 +332,7 @@ test_that("get_single_file_metadata processes empty files correctly", {
   file.create(testfile)
   test_time <- as.POSIXct("2020-01-01T12:34:56+00:00")
   Sys.setFileTime(testfile, test_time)
-  metadata <- get_single_file_metadata(testfile)
+  metadata <- get_single_file_metadata(testfile, summary_info = TRUE)
   expect_identical(
     metadata,
     list(


### PR DESCRIPTION
Adds an argument to `get_single_file_metadata()` (and up through the chain to `export_manifest()`) to include the "summary info" section of file metadata.

In its current implementation, this section provides information about the contents of a file (as interpreted by R), such as rowcount, vector/list length, and class information. However, it did require reading the files, which introduces a non-negligible (putting it nicely) penalty on performance.

Given that we regularly deal with multi-GB files, I've elected to make the default `FALSE`, but the functionality exists for anyone who wants to use it.

Closes #14 