### PR TITLE
Set `jsonvalidate` as a strong dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,13 +19,13 @@ Imports:
     digest,
     gert,
     jsonlite,
+    jsonvalidate,
     logger,
     pkgdepends,
     pkgload
 Suggests: 
     covr,
     devtools,
-    jsonvalidate,
     pak,
     testthat (>= 3.0.0),
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.workflow.utils
 Title: Utility functions for PACTA workflows
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",


### PR DESCRIPTION
Moving to strong dependency, since this is used in `parse_params` and `parse_raw_params`