### PR TITLE
Remove default `force_array` for `parse_raw_params`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.workflow.utils
 Title: Utility functions for PACTA workflows
-Version: 0.0.0.9015
+Version: 0.0.0.9016
 Authors@R: 
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/parse_raw_params.R
+++ b/R/parse_raw_params.R
@@ -10,6 +10,8 @@
 #' `parse_params` for details.
 #' @param raw_schema_file JSON Schema file to validate raw parameters against.
 #' See `jsonvalidate::json_validate` for details.
+#' @param force_array Path in params list to force casting as JSON array.
+#' Passed to `parse_params` agument `force_array`. (Default empty)
 #' @return list of parameters
 #' @examples
 # nolint start
@@ -102,7 +104,8 @@ parse_raw_params <- function(
   json,
   inheritence_search_paths = NULL,
   schema_file = NULL,
-  raw_schema_file = NULL
+  raw_schema_file = NULL,
+  force_array = list()
 ) {
   # Read Params
   log_debug("Processing input parameters.")
@@ -146,7 +149,7 @@ parse_raw_params <- function(
     json = json,
     inheritence_search_paths = inheritence_search_paths,
     schema_file = schema_file,
-    force_array = c("portfolio", "files")
+    force_array = force_array
   )
 
   return(params)

--- a/R/parse_raw_params.R
+++ b/R/parse_raw_params.R
@@ -11,7 +11,7 @@
 #' @param raw_schema_file JSON Schema file to validate raw parameters against.
 #' See `jsonvalidate::json_validate` for details.
 #' @param force_array Path in params list to force casting as JSON array.
-#' Passed to `parse_params` agument `force_array`. (Default empty)
+#' Passed to `parse_params` argument `force_array`. (Default empty)
 #' @return list of parameters
 #' @examples
 # nolint start

--- a/man/parse_raw_params.Rd
+++ b/man/parse_raw_params.Rd
@@ -8,7 +8,8 @@ parse_raw_params(
   json,
   inheritence_search_paths = NULL,
   schema_file = NULL,
-  raw_schema_file = NULL
+  raw_schema_file = NULL,
+  force_array = list()
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ inheritance files. See \code{parse_params} for details.}
 
 \item{raw_schema_file}{JSON Schema file to validate raw parameters against.
 See \code{jsonvalidate::json_validate} for details.}
+
+\item{force_array}{Path in params list to force casting as JSON array.
+Passed to \code{parse_params} agument \code{force_array}. (Default empty)}
 }
 \value{
 list of parameters

--- a/man/parse_raw_params.Rd
+++ b/man/parse_raw_params.Rd
@@ -25,7 +25,7 @@ inheritance files. See \code{parse_params} for details.}
 See \code{jsonvalidate::json_validate} for details.}
 
 \item{force_array}{Path in params list to force casting as JSON array.
-Passed to \code{parse_params} agument \code{force_array}. (Default empty)}
+Passed to \code{parse_params} argument \code{force_array}. (Default empty)}
 }
 \value{
 list of parameters


### PR DESCRIPTION
The prior default (`c("portfolio", "files")`) was causing errors in tests, and setting it to be an empty default makes sense, when there is no guarantee that the invocation pattern will match that pattern at run time